### PR TITLE
Update context-include for models library classes

### DIFF
--- a/diffblue-base.json
+++ b/diffblue-base.json
@@ -2,6 +2,15 @@
   "phaseBase": {
     "javaVersion": 6,
     "preferDepsJar": true,
-    "context-include": [ "com.jsoniter.", "java.", "org.cprover." ]
+    "context-include": [
+      "com.jsoniter.",
+      "com.diffblue.annotation.",
+      "java.",
+      "org.cprover.",
+      "org.slf4j.",
+      "sun.misc.",
+      "sun.nio.cs.",
+      "sun.util."
+    ]
   }
 }


### PR DESCRIPTION
I previously only listed `java.` and `org.cprover.` as prefixes for the models library. This is now the full list (at the moment).